### PR TITLE
Add console focus indicator

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -369,6 +369,7 @@ h3 {
   }
 }
 
+@import 'pages/machine/console.css.scss';
 @import 'pages/*';
 @import 'views/**/*';
 //@import 'vendor/*.css.scss';

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -369,7 +369,6 @@ h3 {
   }
 }
 
-@import 'pages/machine/console.css.scss';
 @import 'pages/*';
 @import 'views/**/*';
 //@import 'vendor/*.css.scss';

--- a/app/assets/stylesheets/bootstrap-customize.css.scss
+++ b/app/assets/stylesheets/bootstrap-customize.css.scss
@@ -13,6 +13,9 @@ $grouping-active: #F7F0F1;
 $grouping-color: #9E8697;
 $light: $grouping-bg;
 
+$active-pink: #E1DFD8;
+$inactive-grey: #EC4863;
+
 // Bootstrap overrides, lookup the names at http://getbootstrap.com/customize/
 $text-color: #554F57;
 $brand-primary: $medium-dark;

--- a/app/assets/stylesheets/pages/machine/console.css.scss
+++ b/app/assets/stylesheets/pages/machine/console.css.scss
@@ -13,6 +13,22 @@
       background-color: $cream-color;
       @include transition(margin-left, 0.5s, ease-in, 0s);
 
+      .focus-indicator {
+        position: absolute;
+        width: 8px;
+        height: 8px;
+        right: 16px;
+        top: 16px;
+        border-radius: 4px;
+        background-color: #E1DFD8;
+
+        @include transition(background, 0.2s, ease-in, 0s);
+      }
+
+      &.focused .focus-indicator {
+        background-color: #EC4863;
+      }
+
       .canvas-wrapper {
         box-sizing: border-box;
         background-color: black;

--- a/app/assets/stylesheets/pages/machine/console.css.scss
+++ b/app/assets/stylesheets/pages/machine/console.css.scss
@@ -20,13 +20,13 @@
         right: 16px;
         top: 16px;
         border-radius: 4px;
-        background-color: #E1DFD8;
+        background-color: $active-pink;
 
         @include transition(background, 0.2s, ease-in, 0s);
       }
 
       &.focused .focus-indicator {
-        background-color: #EC4863;
+        background-color: $inactive-grey;
       }
 
       .canvas-wrapper {

--- a/app/views/machines/index/_console.html.slim
+++ b/app/views/machines/index/_console.html.slim
@@ -1,6 +1,7 @@
 #page-console.text-center(ng-class="{focused: consoleFocused}")
   .console-window-wrapper
     .console-window(ng-class="{focused: consoleFocused}")
+      .focus-indicator
       console password=@machine.vnc_password uuid=@machine.uuid focused="consoleFocused" state="data" control='console'
       .vm-actions
         .iso


### PR DESCRIPTION
This PR is for adding console focus indicator described in virtkick/virtkick#86, screenshot after implementing:

![focus-indicator](https://cloud.githubusercontent.com/assets/3458255/5662347/2a9dada2-9738-11e4-99ba-72bae833f7b8.png)


